### PR TITLE
Add 'version' and 'issue_tracker' keys

### DIFF
--- a/custom_components/xiaomi_miio_airconditioningcompanion/manifest.json
+++ b/custom_components/xiaomi_miio_airconditioningcompanion/manifest.json
@@ -2,6 +2,8 @@
   "domain": "xiaomi_miio_airconditioningcompanionmcn02",
   "name": "Xiaomi Air Conditioning Companion 2",
   "documentation": "https://github.com/EugeneLiu/xiaomi_airconditioningcompanionMCN02",
+  "issue_tracker": "https://github.com/EugeneLiu/xiaomi_airconditioningcompanionMCN02/issues",
+  "version": "0.1.7",
   "requirements": [
     "construct==2.9.45",
     "python-miio>0.5.3"


### PR DESCRIPTION
To avoid disabled in HomeAssistant 2021.6