### PR TITLE
load temperature state immediately when home assistant startup

### DIFF
--- a/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
+++ b/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
@@ -264,6 +264,7 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
         if new_state is None:
             return
         await self._async_update_temp(new_state)
+        await self.async_update_ha_state()
 
     async def _async_power_sensor_changed(self, entity_id, old_state, new_state):
         """Handle power sensor changes."""
@@ -271,6 +272,7 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
             return
 
         await self._async_update_power_state(new_state)
+        await self.async_update_ha_state()
 
     async def _try_command(self, mask_error, func, *args, **kwargs):
         """Call a AC companion command handling error messages."""


### PR DESCRIPTION
by now the component not update home assistant state on home assitant startuping, this PR fix the problem, the temperature state would immediately loaded after startup.